### PR TITLE
feat: automate PyPi package publishing with GitHub Actions

### DIFF
--- a/.github/workflows/publish-package-on-release.yaml
+++ b/.github/workflows/publish-package-on-release.yaml
@@ -1,0 +1,25 @@
+name: Publish package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Publish package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:         
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          pip install poetry poetry-dynamic-versioning
+      - name: Publish package on pypi
+        run: |
+          poetry build
+          poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ the `triggercmd` package is available in [PyPI](https://pypi.org/project/trigger
 ```
 pip install triggercmd
 ```
+Or using the [pipx](https://github.com/pypa/pipx) for a safer installation.
+
 After install, you can use the triggercmd CLI client to manipulate commands on the TRIGGERcmd agent.
 
 ## commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,8 @@ typer-cli = "^0.0.12"
 triggercmd = 'triggercmd_cli.main:run'
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry-dynamic-versioning]
+enable = true


### PR DESCRIPTION
Hi @GussSoares . I create a workflow to automate the pypi package publishing on a github release. Now, every time you create a release on github, the package will be published in pypi with the release tag. You have to create two secret variables:
 - `PYPI_USERNAME` : with your pypi username as value
 - `PYPI_PASSWORD`: with your pypi password as value

in short, I made these changes:
 - created a workflow
 - modified the pyprojet file